### PR TITLE
Exclude broken release only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "symfony/event-dispatcher": "~2.1",
         "symfony/stopwatch":        "~2.3",
         "symfony/config":           "~2.3",
-        "jms/serializer":           "1.7.*",
+        "jms/serializer":           ">=0.12, !=1.8.0",
 
         "herrera-io/phar-update": "1.0.3",
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "ad3774f1303cb41167768021f0946f1d",
+    "content-hash": "68c55becc13d5df0e49d8234f3c600e3",
     "packages": [
         {
             "name": "cilex/cilex",


### PR DESCRIPTION
This should fix travis failures induced by incompatible `1.7.*` version constraint for older versions of PHP.